### PR TITLE
Add promise to publish warning of exclusive right

### DIFF
--- a/index.json
+++ b/index.json
@@ -15,6 +15,9 @@
         "I hereby contribute the finding to the public domain."
       ],
       [
+        "I promise to publish a warning if I become aware of any patent, patent application, or other exclusive claim that might limit who can legally use the finding, or how, as long as I can legally do so."
+      ],
+      [
         "I grant everyone a license for the written material I am submitting, to do everything that would otherwise violate exclusive rights in it, under copyright and other intellectual property laws, on two conditions:",
         [
           "No one may distribute or display changed copies without indicating what has been changed.",


### PR DESCRIPTION
This PR reintroduces text from earlier versions of the PDC Legal Tool and one of its predecessors, the PDC Declaration. The language gives a promise to publish notice if the contributor becomes aware that what they's contributed might be subject to exclusive rights, such as a patent.

The main point of this language was to try to avoid situations where a PDC record seems to say that a finding is free to use, when in fact a patent or other exclusive right applies, and one who made the submission finds out. PDC records are _never_ sufficient, from the freedom-to-operate researcher's point of view, to show that something is definitively unencumbered by patents. But they're evidence pointing in that direction, and as such potentially misleading.

Part of the motivation for this language was to address the one-year, 102(b) grace period under US patent law, which allows inventors to file for and receive patents up to one year _after_ publication that would otherwise preclude as prior art.

There are at least two reasons to think this approach is dubious enough to dispense with:

1. PDC publications be anonymous. It won't be clear who's giving any kind of public promise.  That's more important with a promise than with an act, like publication, that has legal effect in and of itself.

2. PDC doesn't currently have any kind of interface or standard format for these notices.  We could come up with one, but it'd take a little work.